### PR TITLE
Replace Gmail with Mailgun as SMTP provider

### DIFF
--- a/ghost/ghost.values.yaml
+++ b/ghost/ghost.values.yaml
@@ -139,11 +139,11 @@ service:
   type: ClusterIP
 sidecars: []
 smtpExistingSecret: ''
-smtpHost: 'smtp.gmail.com'
+smtpHost: smtp.mailgun.org
 smtpPassword: '<<password>>'
-smtpPort: '465'
-smtpService: 'gmail'
-smtpUser: 'mail-server@podkrepi.bg'
+smtpPort: '587'
+smtpService: mailgun
+smtpUser: postmaster@sandbox7ffd6551a07a492c8f905cad9fbe11cd.mailgun.org
 tolerations: {}
 updateStrategy:
   type: RollingUpdate

--- a/ghost/ghost.values.yaml
+++ b/ghost/ghost.values.yaml
@@ -139,11 +139,11 @@ service:
   type: ClusterIP
 sidecars: []
 smtpExistingSecret: ''
-smtpHost: smtp.mailgun.org
+smtpHost: smtp.eu.mailgun.org
 smtpPassword: '<<password>>'
 smtpPort: '587'
 smtpService: mailgun
-smtpUser: postmaster@sandbox7ffd6551a07a492c8f905cad9fbe11cd.mailgun.org
+smtpUser: postmaster@podkrepi.bg
 tolerations: {}
 updateStrategy:
   type: RollingUpdate


### PR DESCRIPTION
Replace Gmail SMTP provider as they have changed their sending policy recently and now it throws errors:

```
Error sending email! Error sending email: Failed to send email. Reason: Invalid login: 535-5.7.8 Username and Password not accepted. Learn more at 535 5.7.8 https://support.google.com/mail/?p=BadCredentials c1-20020a196541000000b00448bcdccb91sm906496lfj.231 - gsmtp. Please check your email settings and resend the invitation.
```

