### PR TITLE
Enable token_exchange for keycloak

### DIFF
--- a/keycloak/keycloak-helm-values.yaml
+++ b/keycloak/keycloak-helm-values.yaml
@@ -56,7 +56,7 @@ extraDeploy: []
 extraEnvVars: []
 extraEnvVarsCM: ''
 extraEnvVarsSecret: ''
-extraStartupArgs: ''
+extraStartupArgs: '-Dkeycloak.profile.feature.token_exchange=enabled -Dkeycloak.profile.feature.admin_fine_grained_authz=enabled'
 extraVolumeMounts:
   - mountPath: /opt/bitnami/keycloak/themes/podkrepi
     name: theme


### PR DESCRIPTION

## Motivation and context
The change enables token_exchange feature for Google Sign-in with Keycloak
